### PR TITLE
Bug fix for slug post retrieval

### DIFF
--- a/src/app/api/posts/[slug]/route.ts
+++ b/src/app/api/posts/[slug]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
     const { slug } = params
     console.log('API [slug] - Searching for slug:', slug)
 
-    const post = await prisma.post.findUnique({
+    const post = await prisma.post.findFirst({
       where: {
         slug,
         status: 'PUBLISHED'


### PR DESCRIPTION
## Summary
- use `findFirst` when retrieving a published post by slug so drafts are ignored

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68546893d2b8832eae326fc8af65788b